### PR TITLE
feat: Add support for slashes in package name

### DIFF
--- a/src/utils/AbsoluteImportResolver.ts
+++ b/src/utils/AbsoluteImportResolver.ts
@@ -20,7 +20,7 @@ export namespace AbsoluteImportResolver {
 
             let resolvedToPackageName: string | null = null;
             packageNames.forEach(packageName => {
-                const paths = tsConfig.paths[packageName];
+                const paths = tsConfig.paths[packageName].map(x => x.replace(/\/\*$/, ""));
 
                 if (
                     paths.some(partialPath => {
@@ -36,7 +36,7 @@ export namespace AbsoluteImportResolver {
                     if (resolvedToPackageName && IS_DEBUG_ENABLED) {
                         console.warn(`Multiple configured paths matching to path '${filePath}'`);
                     } else {
-                        resolvedToPackageName = packageName;
+                        resolvedToPackageName = packageName.replace(/\/\*$/, "");
                     }
                 }
             });

--- a/src/utils/DirUtils.ts
+++ b/src/utils/DirUtils.ts
@@ -3,7 +3,7 @@ export namespace DirUtils {
         return cleanPath(filePath).split("/");
     }
 
-    function cleanPath(filePath: string): string {
+    export function cleanPath(filePath: string): string {
         let cleaned = filePath.trim();
 
         cleaned = cleaned.replace(/['"]+/g, "");

--- a/src/utils/ImportRuleUtils.ts
+++ b/src/utils/ImportRuleUtils.ts
@@ -34,13 +34,11 @@ export namespace ImportRuleUtils {
         tsConfig: TsConfig,
         thisPackageLocation?: PackageLocation
     ): PackageLocation {
-        const dirs = DirUtils.splitPath(filePath);
-
         if (IS_DEBUG_ENABLED) {
-            console.log(`\nchecking ${PathSource[pathSource]} against path:`, dirs.join(","));
+            console.log(`\nchecking ${PathSource[pathSource]} against path:`, filePath);
         }
 
-        let packageName = determinePackageName(config, filePath, pathSource, tsConfig);
+        let [packageName, dirs] = determinePackageName(config, filePath, pathSource, tsConfig);
 
         if (
             packageName === null ||
@@ -135,17 +133,37 @@ export namespace ImportRuleUtils {
         filePath: string,
         pathSource: PathSource,
         tsConfig: TsConfig
-    ): string | null {
+    ): [string | null, string[]] {
         let packageName: string | null = null;
+        let dirs: string[] = [];
+
+        let clearedFilePath = DirUtils.cleanPath(filePath);
         switch (pathSource) {
             case PathSource.ImportText:
                 {
-                    // take the 1st part of the path:
+                    // take the biggest part known to be a package:
+                    let lastSlashIndex = Infinity;
+                    while (lastSlashIndex !== -1) {
+                        let head = clearedFilePath.substring(0, lastSlashIndex);
+                        if (PackageConfigHelper.hasPackage(config, head)) {
+                            dirs.unshift(head);
+                            break;
+                        }
+
+                        const slashIndex = clearedFilePath.lastIndexOf("/", lastSlashIndex - 1);
+                        const part = clearedFilePath.substring(slashIndex + 1, lastSlashIndex);
+                        dirs.unshift(part);
+
+                        lastSlashIndex = slashIndex;
+                    }
+
                     // (ignore local directories that happen to have same name as a package)
-                    packageName = DirUtils.splitPath(filePath)[0];
+                    packageName = dirs[0];
                 }
                 break;
             case PathSource.SourceFilePath: {
+                dirs = clearedFilePath.split("/");
+
                 const pathName = AbsoluteImportResolver.resolvePathToPackageName(
                     filePath,
                     tsConfig,
@@ -162,7 +180,7 @@ export namespace ImportRuleUtils {
             }
         }
 
-        return packageName;
+        return [packageName, dirs];
     }
 
     function determinePackageLocationWithSubFolder(

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/invalid-import.imports-self.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/invalid-import.imports-self.ts.lint
@@ -1,0 +1,6 @@
+import {SomeClass} from "lodash";
+import {SomeClass} from "@my/viewer-api/someCode";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [do not import a package from itself - use a relative path (tsf-folders-imports-between-packages)]
+import {SomeClass} from "../someCode";
+// some local directory that happens to use the package name:
+import {SomeClass} from "../../../my-viewer-api/stores/AssistStore";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/invalid-imports.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/invalid-imports.ts.lint
@@ -1,0 +1,5 @@
+import {SomeClass} from "third-party/someCode";
+
+import {SomeCode} from "@my/viewer";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ['@my/viewer-api' is not allowed to import from '@my/viewer' (tsf-folders-imports-between-packages)]
+// note: for this detection to work, we need to process the paths in tsconfig.json

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/valid-import.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/valid-import.ts.lint
@@ -1,0 +1,5 @@
+import {SomeClass} from "lodash";
+
+import {SomeCode} from "thirdPartySdk";
+
+import {SomeClass} from "../someCode";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/valid-relative-import-shell.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/api/valid-relative-import-shell.ts.lint
@@ -1,0 +1,5 @@
+// some local directory:
+import {SomeClass} from "../../../my-viewer-api/stores/AssistStore";
+
+// some local directory:
+import {SomeClass} from "../../../my-viewer/stores/AssistStore";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/invalid-import.imports-self.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/invalid-import.imports-self.ts.lint
@@ -1,0 +1,6 @@
+import {SomeClass} from "lodash";
+import {SomeClass} from "@my/viewer/someCode";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [do not import a package from itself - use a relative path (tsf-folders-imports-between-packages)]
+import {SomeClass} from "../someCode";
+// some local directory that happens to use the package name:
+import {SomeClass} from "../../../contact-area-api/stores/AssistStore";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/valid-import.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/valid-import.ts.lint
@@ -1,0 +1,6 @@
+import {SomeClass} from "lodash";
+
+import {SomeCode} from "@my/viewer-api";
+import {SomeCode} from "thirdPartySdk";
+
+import {SomeClass} from "../someCode";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/valid-relative-import-shell.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/my-viewer/src/valid-relative-import-shell.ts.lint
@@ -1,0 +1,2 @@
+// some local directory:
+import {SomeClass} from "../../../shell/stores/AssistStore";

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/utils/invalid-imports.ts.lint
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/src/utils/invalid-imports.ts.lint
@@ -3,3 +3,7 @@ import {SomeClass} from "my-editor/someCode";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ['utils' is not allowed to import from 'my-editor' (tsf-folders-imports-between-packages)]
 import {SomeClass} from "my-editor-api/someCode";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ['utils' is not allowed to import from 'my-editor-api' (tsf-folders-imports-between-packages)]
+import {SomeClass} from "@my/viewer/someCode";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ['utils' is not allowed to import from '@my/viewer' (tsf-folders-imports-between-packages)]
+import {SomeClass} from "@my/viewer-api/someCode";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ['utils' is not allowed to import from '@my/viewer-api' (tsf-folders-imports-between-packages)]

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/tsconfig.json
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/tsconfig.json
@@ -10,8 +10,10 @@
       "baseUrl": ".",
       "strict": true,
       "paths": {
-        "my-editor": ["my-editor/src"],
-        "my-editor-api": ["my-editor/api"]
+        "my-editor/*": ["my-editor/src/*"],
+        "my-editor-api": ["my-editor/api"],
+        "@my/viewer/*": ["my-viewer/src/*"],
+        "@my/viewer-api": ["my-viewer/api"]
       }
     },
     "include": ["src"]

--- a/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/tslint.json
+++ b/test/rules/tsf-folders-imports-between-packages/tsconfigPaths/tslint.json
@@ -32,7 +32,19 @@
                 "importPath": "my-editor-api",
                 "allowedToImport": ["thirdPartySdk", "utils"],
                 "subFolders": []
-              },           
+              },
+              {
+                "description": "My Viewer",
+                "importPath": "@my/viewer",
+                "allowedToImport": ["*"],
+                "subFolders": []
+              },
+              {
+                "description": "My Viewer API",
+                "importPath": "@my/viewer-api",
+                "allowedToImport": ["thirdPartySdk", "utils"],
+                "subFolders": []
+              },
               {
                 "description": "Utils package",
                 "importPath": "utils",

--- a/test/tslint-folders.test.ts
+++ b/test/tslint-folders.test.ts
@@ -25,7 +25,9 @@ describe("tslint-folders tests", () => {
         expect(true).toBeTruthy();
     });
 
-    const testDirectories = glob.sync("test/rules/**/tslint.json").map(path.dirname);
+    const testDirectories = glob
+        .sync("test/rules/**/tslint.json", { absolute: true })
+        .map(path.dirname);
 
     describe("standard tslint test runner (NO code coverage!)", () => {
         for (const testDirectory of testDirectories) {
@@ -63,22 +65,8 @@ describe("tslint-folders tests", () => {
                         // perform a crude check - the tslint test runner already performs detailed checks
                         const errorsFromMarkup = parse.parseErrorsFromMarkup(sourceFile.text);
 
-                        // TODO xxx why are these tests failing? (they pass for non-jest test run!)
-                        if (
-                            fileToLint.endsWith(
-                                "/my-editor/src/invalid-import.imports-self.ts.lint"
-                            ) ||
-                            fileToLint.endsWith(
-                                "/my-editor/api/invalid-import.imports-self.ts.lint"
-                            )
-                        ) {
-                            console.warn(`skipping test file '${fileToLint}'`);
-                        } else {
-                            // "debug statement" and "call expression" can double up:
-                            expect(ruleFailures.length).toBeGreaterThanOrEqual(
-                                errorsFromMarkup.length
-                            );
-                        }
+                        // "debug statement" and "call expression" can double up:
+                        expect(ruleFailures.length).toBeGreaterThanOrEqual(errorsFromMarkup.length);
                     });
                 }
             });


### PR DESCRIPTION
1. Added support for slashes in package names
    Changes are in `ImportRuleUtils::determinePackageName`. Instead of assuming that the first part is a package we look for the biggest portion that corresponds to an existing package.
2. Added support for `/*` in tsconfig paths as it often used there.
    Changes are in `AbsoluteImportResolver::resolvePathToPackageName`.
3. Fixed small issue in coverage test run - no need to skip some of the tests
    Was caused by `glob.sync` returning relative path that lead to a failure of `startsWith` check in `AbsoluteImportResolver::resolvePathToPackageName`

fix #26 